### PR TITLE
fix: fixing login selector for new changes on the site

### DIFF
--- a/visa.py
+++ b/visa.py
@@ -100,7 +100,8 @@ def login():
     time.sleep(STEP_TIME)
 
     print("Login start...")
-    href = driver.find_element(By.XPATH, '//*[@id="header"]/nav/div[2]/div[1]/ul/li[3]/a')
+    href = driver.find_element(By.XPATH, '//*[@id="header"]/nav/div[1]/div[1]/div[2]/div[1]/ul/li[3]/a')
+   
     href.click()
     time.sleep(STEP_TIME)
     Wait(driver, 60).until(EC.presence_of_element_located((By.NAME, "commit")))


### PR DESCRIPTION
The script was failing due to a new change in the HTML structure affecting the login selector. 
