### PR TITLE
Update webdriver-manager version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 selenium==4.2.0
-webdriver-manager==3.7.0
+webdriver-manager==4.0.1
 requests==2.27.1
 sendgrid==6.9.7


### PR DESCRIPTION
The webdriver-manager version specified in requirements.txt causes the script to fail with ValueError: There is no such driver by url https://chromedriver.storage.googleapis.com/LATEST_RELEASE_118.0.5993. Upgrading the version makes everything work!

For consistency, I have replaced the version with the latest one right now.